### PR TITLE
Fix regression in file name for SID named databases and file extension case insensitivity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn dump(
 fn is_valid_file(p: &PathBuf) -> bool {
     let is_valid_name = p.file_stem()
         .and_then(|s| s.to_str())
-        .map_or(false, |name| name.eq_ignore_ascii_case("windows") || name.starts_with("s-1-"));
+        .map_or(false, |name| name.eq_ignore_ascii_case("windows") || name.to_ascii_lowercase().starts_with("s-1-"));
     let is_valid_ext = p.extension()
         .and_then(|e| e.to_str())
         .map_or(false, |ext| ext == "edb" || ext == "db");

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,8 @@ fn dump(
                     dump(&p, report_prod, status_logger)?;
                 } else if is_valid_file(&p) {
                     processed += 1;
-                    let _ = match p.extension().and_then(|e| e.to_str()) {
+                    let ext = p.extension().and_then(|e| e.to_str()).map(|s| s.to_lowercase());
+                    let _ = match ext.as_deref() {
                         Some("edb") => ese_generate_report(&p, report_prod, status_logger),
                         Some("db") => sqlite_generate_report(&p, report_prod, status_logger),
                         _ => continue,
@@ -71,7 +72,7 @@ fn is_valid_file(p: &PathBuf) -> bool {
         .map_or(false, |name| name.eq_ignore_ascii_case("windows") || name.to_ascii_lowercase().starts_with("s-1-"));
     let is_valid_ext = p.extension()
         .and_then(|e| e.to_str())
-        .map_or(false, |ext| ext == "edb" || ext == "db");
+        .map_or(false, |ext| ext.to_ascii_lowercase() == "edb" || ext.to_ascii_lowercase() == "db");
     is_valid_name && is_valid_ext
 }
 


### PR DESCRIPTION
Great work on the fixes @juliapaluch. This is a quick fix to allow SID named ones to work with capital letters so S-1-5- rather than just s-1-5-

Seems like .db and .edb aren't case sensitive either which this pull request also solves as .DB and .EDB now work. Check that these are correct as I am not very familiar with Rust but you should get the idea of what I am wanting to cover with these fixes